### PR TITLE
Fixed memory error problem

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -37,7 +37,9 @@ python main.py
 ### Virtual environment on Windows (Python 2.x):
 ```
 python -m virtualenv .venv
-.venv\Scripts\activate.bat
+cd .venv/Scripts
+activate.bat
+cd ../..
 pip install -r requirements2x.txt
 python main.py
 ```

--- a/README.MD
+++ b/README.MD
@@ -23,7 +23,7 @@ pip install -r requirements.txt
 python3 main.py
 ```
 
-### Virtual environment on Windows:
+### Virtual environment on Windows (Python 3.x):
 
 ```
 python -m venv .venv
@@ -31,6 +31,14 @@ cd .venv/Scripts
 activate.bat
 cd ../..
 pip install -r requirements.txt
+python main.py
+```
+
+### Virtual environment on Windows (Python 2.x):
+```
+python -m virtualenv .venv
+.venv\Scripts\activate.bat
+pip install -r requirements2x.txt
 python main.py
 ```
 

--- a/main.py
+++ b/main.py
@@ -39,14 +39,16 @@ for url, title, author, pk_name in tqdm(books[['OpenURL', 'Book Title', 'Author'
 
     final = new_url.split('/')[-1]
     final = title.replace(',','-').replace('.','').replace('/',' ').replace(':',' ') + ' - ' + author.replace(',','-').replace('.','').replace('/',' ').replace(':',' ') + ' - ' + final
+    final = final.encode('ascii', 'ignore').decode('ascii')
+    final = (final[:145] + '.pdf') if len(final) > 145 else final
     output_file = os.path.join(new_folder, final)
-
+    
     if not os.path.exists(output_file.encode('utf-8')):
         myfile = requests.get(new_url, allow_redirects=True)
         try:
             open(output_file.encode('utf-8'), 'wb').write(myfile.content)
         except OSError: 
-            print("Error: PDF filename is appears incorrect.")
+            print("Error: PDF filename appears incorrect.")
         
         #download epub version too if exists
         new_url = r.url
@@ -57,6 +59,8 @@ for url, title, author, pk_name in tqdm(books[['OpenURL', 'Book Title', 'Author'
 
         final = new_url.split('/')[-1]
         final = title.replace(',','-').replace('.','').replace('/',' ').replace(':',' ') + ' - ' + author.replace(',','-').replace('.','').replace('/',' ').replace(':',' ') + ' - ' + final
+        final = final.encode('ascii', 'ignore').decode('ascii')
+        final = (final[:145] + '.epub') if len(final) > 145 else final
         output_file = os.path.join(new_folder, final)
         
         request = requests.get(new_url)
@@ -65,6 +69,6 @@ for url, title, author, pk_name in tqdm(books[['OpenURL', 'Book Title', 'Author'
             try:
                 open(output_file.encode('utf-8'), 'wb').write(myfile.content)
             except OSError: 
-                print("Error: EPUB filename is appears incorrect.")
+                print("Error: EPUB filename appears incorrect.")
             
 print('Download finished.')

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ for url, title, author, pk_name in tqdm(books[['OpenURL', 'Book Title', 'Author'
     output_file = os.path.join(new_folder, final)
 
     if not os.path.exists(output_file.encode('utf-8')):
-        with requests.get(url, stream=True) as r:
+        with requests.get(new_url, stream=True) as r:
             try:
                 with open(output_file.encode('utf-8'), 'wb') as f:
                     shutil.copyfileobj(r.raw, f)
@@ -67,7 +67,7 @@ for url, title, author, pk_name in tqdm(books[['OpenURL', 'Book Title', 'Author'
 
         request = requests.get(new_url)
         if request.status_code == 200:
-            with requests.get(url, stream=True) as r:
+            with requests.get(new_url, stream=True) as r:
                 try:
                     with open(output_file.encode('utf-8'), 'wb') as f:
                         shutil.copyfileobj(r.raw, f)

--- a/requirements2x.txt
+++ b/requirements2x.txt
@@ -1,0 +1,15 @@
+certifi==2020.4.5.1
+chardet==3.0.4
+et-xmlfile==1.0.1
+idna==2.9
+jdcal==1.4.1
+numpy==1.16.6
+openpyxl==2.6.4
+pandas==0.24.2
+python-dateutil==2.8.1
+pytz==2019.3
+requests==2.23.0
+six==1.14.0
+tqdm==4.45.0
+urllib3==1.25.8
+xlrd==1.2.0


### PR DESCRIPTION
The original code keeps the download content in the memory before writing to the file. If the file is very large, then it will cause memory error in the `requests.get()`. I fixed it by using streaming mode, thus it resolves #33.

I added `requirements2x.txt` for python 2.7.x users. I know I should be upgrading to Python 3 ;-)

I also fixed filename-too-long issue by truncating it. Some files have names longer than 150 characters, thus generating `IOError`. It happens under Python 2.7.x. I am not sure if Python 3 has the same issue or not.