### PR TITLE
Avoid incomplete downloaded book from being taken as valid one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
+tmp/
 downloads/
 eggs/
 .eggs/

--- a/helper.py
+++ b/helper.py
@@ -1,0 +1,40 @@
+import os
+import requests
+import shutil
+
+
+def create_relative_path_if_not_exist(relative_path):
+    path = os.path.join(os.getcwd(), relative_path)
+    if not os.path.exists(path):
+        os.makedirs(path)
+    return path
+
+
+def download_book(url, bookpath):
+    if not os.path.exists(bookpath):
+        with requests.get(url, stream = True) as req:
+            path = create_relative_path_if_not_exist('tmp')
+            tmp_file = os.path.join(path, '_-_temp_file_-_.bak')
+            with open(tmp_file, 'wb') as out_file:
+                shutil.copyfileobj(req.raw, out_file)
+                out_file.close()
+            shutil.move(tmp_file, bookpath)
+
+
+replacements = {'/':'-', '\\':'-', ':':'-', '*':'', '>':'', '<':'', '?':'', \
+                '|':'', '"':''}
+
+
+def compose_bookname(title, author, edition, isbn):
+    bookname = title + ' - ' + author + ', ' + edition + ' - ' + isbn
+    if(len(bookname) > 145):
+        bookname = title + ' - ' + author.split(',')[0] + ' et al., ' + \
+                    edition + ' - ' + isbn
+    if(len(bookname) > 145):
+        bookname = title + ' - ' + author.split(',')[0] + ' et al. - ' + isbn
+    if(len(bookname) > 145):
+        bookname = title + ' - ' + isbn
+    if(len(bookname) > 145):
+        bookname = title[:130] + ' - ' +isbn
+    bookname = bookname.encode('ascii', 'ignore').decode('ascii')
+    return "".join([replacements.get(c, c) for c in bookname])

--- a/main.py
+++ b/main.py
@@ -2,76 +2,39 @@
 
 import os
 import requests
-import shutil
 import pandas as pd
 from tqdm import tqdm
+from helper import *
 
-# insert here the folder you want the books to be downloaded:
-folder = os.path.join(os.getcwd(), 'downloads')
+folder = create_relative_path_if_not_exist('downloads')
 
-if not os.path.exists(folder):
-    os.mkdir(folder)
-
-if not os.path.exists(os.path.join(folder, "table.xlsx")):
-    books = pd.read_excel('https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/v4')
-
-    # save table:
-    books.to_excel(os.path.join(folder, 'table.xlsx'))
+table_url = 'https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/v4'
+table = 'table_' + table_url.split('/')[-1] + '.xlsx'
+if not os.path.exists(os.path.join(folder, table)):
+    books = pd.read_excel(table_url)
+    # Save table
+    books.to_excel(os.path.join(folder, table))
 else:
-    books = pd.read_excel(os.path.join(folder, 'table.xlsx'), index_col=0, header=0)
-
-print('Download started.')
+    books = pd.read_excel(os.path.join(folder, table), index_col=0, header=0)
 
 
-for url, title, author, pk_name in tqdm(books[['OpenURL', 'Book Title', 'Author', 'English Package Name']].values):
-
-    new_folder = os.path.join(folder, pk_name)
+for url, title, author, edition, isbn, category in tqdm(books[['OpenURL', 'Book Title', 'Author', 'Edition', 'Electronic ISBN', 'English Package Name']].values):
+    new_folder = os.path.join(folder, category)
 
     if not os.path.exists(new_folder):
         os.mkdir(new_folder)
 
     r = requests.get(url)
-    new_url = r.url
+    new_url = r.url.replace('%2F','/').replace('/book/','/content/pdf/') + '.pdf'
+    bookname = compose_bookname(title, author, edition, isbn)
+    output_file = os.path.join(new_folder, bookname + '.pdf')
+    download_book(new_url, output_file)
 
-    new_url = new_url.replace('/book/','/content/pdf/')
+    # Download EPUB version too if exists
+    new_url = r.url.replace('%2F','/').replace('/book/','/download/epub/') + '.epub'
+    output_file = os.path.join(new_folder, bookname + '.epub')
+    request = requests.get(new_url, stream = True)
+    if request.status_code == 200:
+       download_book(new_url, output_file)
 
-    new_url = new_url.replace('%2F','/')
-    new_url = new_url + '.pdf'
-
-    final = new_url.split('/')[-1]
-    final = title.replace(',','-').replace('.','').replace('/',' ').replace(':',' ') + ' - ' + author.replace(',','-').replace('.','').replace('/',' ').replace(':',' ') + ' - ' + final
-    final = final.encode('ascii', 'ignore').decode('ascii')
-    final = (final[:145] + '.pdf') if len(final) > 145 else final
-    output_file = os.path.join(new_folder, final)
-
-    if not os.path.exists(output_file.encode('utf-8')):
-        with requests.get(new_url, stream=True) as req:
-            try:
-                with open(output_file.encode('utf-8'), 'wb') as out_file:
-                    shutil.copyfileobj(req.raw, out_file)
-            except OSError:
-                print("Error: PDF filename appears incorrect.")
-
-        #download epub version too if exists
-        new_url = r.url
-
-        new_url = new_url.replace('/book/','/download/epub/')
-        new_url = new_url.replace('%2F','/')
-        new_url = new_url + '.epub'
-
-        final = new_url.split('/')[-1]
-        final = title.replace(',','-').replace('.','').replace('/',' ').replace(':',' ') + ' - ' + author.replace(',','-').replace('.','').replace('/',' ').replace(':',' ') + ' - ' + final
-        final = final.encode('ascii', 'ignore').decode('ascii')
-        final = (final[:145] + '.epub') if len(final) > 145 else final
-        output_file = os.path.join(new_folder, final)
-
-        request = requests.get(new_url)
-        if request.status_code == 200:
-            with requests.get(new_url, stream=True) as req:
-                try:
-                    with open(output_file.encode('utf-8'), 'wb') as out_file:
-                        shutil.copyfileobj(req.raw, out_file)
-                except OSError:
-                    print("Error: EPUB filename appears incorrect.")
-
-print('Download finished.')
+print('\nFinish downloading.')


### PR DESCRIPTION
Instead of downloading a book directly to its folder, the amended script downloads into a temporary file in the `tmp` folder. If a user hits Ctrl+C or Ctrl+Break, the incomplete book stays in the `tmp` folder. Otherwise, it will be moved over to the intended folder once the download has completed. The amended script also fixes the EPUB being missed out after Ctrl+C or Ctrl+Break and restarting script. Both code fixes solves #41.

I heavily cleaned up the code to keep it D.R.Y. I also improved on the generation of book name. A book name consists of `title` + `author` + `edition` + `isbn`. Most books have quite reasonable title lengths, but the length of author names can be very long. A few books breach the filename's 150 characters limit due to that. The new book name generator keeps it to the limit by trying different combinations. For example, if the author names are too lengthy, it will be shorten to only the first author's name, like `Dietrich Braun et al.`.