### PR TITLE
Fixed issue of missing EPUB and added command-line options

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -10,11 +10,11 @@ Use the following command to download all PDF and EPUB books to the default down
 ```bash
 python3 main.py
 ```
-To download them to a subfolder of your choice, say `books`, type
+To download them to a subfolder of your choice, say `books`
 ```bash
 python3 main.py -f ./books
 ```
-You can download to an absolute path, say 'C:/ebooks/springer/'
+You can download to an absolute path, say `C:/ebooks/springer/`
 ```bash
 python3 main.py -f C:/ebooks/springer/
 ```

--- a/README.MD
+++ b/README.MD
@@ -7,25 +7,25 @@ By default the script stores the books in `./downloads` subfolder (created if no
 
 #### Download all books (PDF and EPUB)
 Use the following command to download all PDF and EPUB books to the default download folder `./downloads`
-```python
+```bash
 python3 main.py
 ```
 To download them to a subfolder of your choice, say `books`, type
-```python
+```bash
 python3 main.py -f ./books
 ```
 You can download to an absolute path, say 'C:/ebooks/springer/'
-```python
+```bash
 python3 main.py -f C:/ebooks/springer/
 ```
 
 #### Download all books of specific format
 To download all PDF books only, run
-```python
+```bash
 python3 main.py --pdf
 ```
 or all EPUB books only,
-```python
+```bash
 python3 main.py --epub
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -3,10 +3,10 @@
 ### Usage
 **Note**: If you want just one or two specific books, get the excel file [here](https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/v4) and manually download those. It took about 4 hours to complete the 409 english books (14 GB, both PDF and EPUB) on my machine.
 
-By default the script stores the books in `/downloads/` subfolder (created if not exists) according to the subject ("English Package Name" column of the excel file).
+By default the script stores the books in `./downloads` subfolder (created if not exists) according to the subject ("English Package Name" column of the excel file).
 
 #### Download all books (PDF and EPUB)
-Use the following command to download all PDF and EPUB books
+Use the following command to download all PDF and EPUB books to the default download folder `./downloads`
 ```python
 python3 main.py
 ```

--- a/README.MD
+++ b/README.MD
@@ -1,20 +1,35 @@
 ## Python script to download all Springer books released for free during the 2020 COVID-19 quarantine
 
 ### Usage
+**Note**: If you want just one or two specific books, get the excel file [here](https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/v4) and manually download those. It took about 4 hours to complete the 409 english books (14 GB, both PDF and EPUB) on my machine.
 
-Just run the script in the desired folder. It will automatically create a `/download/` subfolder and will categorize the books acording the subject.
+By default the script stores the books in `/downloads/` subfolder (created if not exists) according to the subject ("English Package Name" column of the excel file).
 
-If you want to manually set a folder to download, insert `folder = 'C:/desired_folder/'` in `main.py`.
+#### Download all books (PDF and EPUB)
+Use the following command to download all PDF and EPUB books
+```python
+python3 main.py
+```
+To download them to a subfolder of your choice, say `books`, type
+```python
+python3 main.py -f ./books
+```
+You can download to an absolute path, say 'C:/ebooks/springer/'
+```python
+python3 main.py -f C:/ebooks/springer/
+```
 
-The books are now organized in sub folders according to the subject ("English Package Name" column).
+#### Download all books of specific format
+To download all PDF books only, run
+```python
+python3 main.py --pdf
+```
+or all EPUB books only,
+```python
+python3 main.py --epub
+```
 
-Now updated to also download epub files if it's available.
-
-If you want just one or two specific books, get the excel file from the folowing link and download just those: https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/v4
-
-It took about 4 hours to complete the 409 english books (14 GB, both PDF and epub) on my machine.
-
-### Usage in a virtual environment:
+### Running in a virtual environment:
 
 ```bash
 python3 -m venv .venv
@@ -40,12 +55,34 @@ pip install -r requirements2x.txt
 python main.py
 ```
 
+
+
 ### Source:
 * https://group.springernature.com/gp/group/media/press-releases/freely-accessible-textbook-initiative-for-educators-and-students/17858180?utm_medium=social&utm_content=organic&utm_source=facebook&utm_campaign=SpringerNature_&sf232256230=1
 * https://www.springernature.com/gp/librarians/news-events/all-news-articles/industry-news-initiatives/free-access-to-textbooks-for-institutions-affected-by-coronaviru/17855960
 * https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/v4
 
 Thanks Springer!
+
+## Docker container to do all the work
+
+Considering you cloned the repo in a folder, as:
+```bash
+cd \home\[user]\workspace`
+git clone https://github.com/alexgand/springer_free_books.git
+cd springer_free_books
+mkdir downloads
+```
+You can run the scripts like that:
+
+```bash
+docker build . -t springer-image
+docker run --rm -v [local_download_folder]:/app/downloads springer-image
+```
+
+and the downloads will be at [local_download_folder]
+
+
 
 ## Docker container to do all the work
 

--- a/helper.py
+++ b/helper.py
@@ -15,7 +15,7 @@ def create_book_file(base_path, bookname, patch):
     return output_file
 
 
-def download_book(url, book_path):
+def _download_book(url, book_path):
     if not os.path.exists(book_path):
         with requests.get(url, stream=True) as req:
             path = create_path('./tmp')
@@ -26,11 +26,11 @@ def download_book(url, book_path):
             shutil.move(tmp_file, book_path)
 
 
-def download_all_books(request, output_file, patch):
+def download_book(request, output_file, patch):
     new_url = request.url.replace('%2F','/').replace('/book/', patch['url']) + patch['ext']
     request = requests.get(new_url, stream=True)
     if request.status_code == 200:
-        download_book(new_url, output_file)
+        _download_book(new_url, output_file)
 
 
 replacements = {'/':'-', '\\':'-', ':':'-', '*':'', '>':'', '<':'', '?':'', \

--- a/helper.py
+++ b/helper.py
@@ -10,19 +10,32 @@ def create_relative_path_if_not_exist(relative_path):
     return path
 
 
-def download_book(url, bookpath):
-    if not os.path.exists(bookpath):
-        with requests.get(url, stream = True) as req:
+def create_book_file(base_path, bookname, patch):
+    output_file = os.path.join(base_path, bookname + patch['ext'])
+    if os.path.exists(output_file):
+        return None
+    return output_file
+
+
+def download_book(url, book_path):
+    if not os.path.exists(book_path):
+        with requests.get(url, stream=True) as req:
             path = create_relative_path_if_not_exist('tmp')
             tmp_file = os.path.join(path, '_-_temp_file_-_.bak')
             with open(tmp_file, 'wb') as out_file:
                 shutil.copyfileobj(req.raw, out_file)
                 out_file.close()
-            shutil.move(tmp_file, bookpath)
+            shutil.move(tmp_file, book_path)
 
 
 replacements = {'/':'-', '\\':'-', ':':'-', '*':'', '>':'', '<':'', '?':'', \
                 '|':'', '"':''}
+
+def download_all_books(request, output_file, patch):
+    new_url = request.url.replace('%2F','/').replace('/book/', patch['url']) + patch['ext']
+    request = requests.get(new_url, stream=True)
+    if request.status_code == 200:
+        download_book(new_url, output_file)
 
 
 def compose_bookname(title, author, edition, isbn):
@@ -35,6 +48,6 @@ def compose_bookname(title, author, edition, isbn):
     if(len(bookname) > 145):
         bookname = title + ' - ' + isbn
     if(len(bookname) > 145):
-        bookname = title[:130] + ' - ' +isbn
+        bookname = title[:130] + ' - ' + isbn
     bookname = bookname.encode('ascii', 'ignore').decode('ascii')
     return "".join([replacements.get(c, c) for c in bookname])

--- a/helper.py
+++ b/helper.py
@@ -28,15 +28,15 @@ def download_book(url, book_path):
             shutil.move(tmp_file, book_path)
 
 
-replacements = {'/':'-', '\\':'-', ':':'-', '*':'', '>':'', '<':'', '?':'', \
-                '|':'', '"':''}
-
 def download_all_books(request, output_file, patch):
     new_url = request.url.replace('%2F','/').replace('/book/', patch['url']) + patch['ext']
     request = requests.get(new_url, stream=True)
     if request.status_code == 200:
         download_book(new_url, output_file)
 
+
+replacements = {'/':'-', '\\':'-', ':':'-', '*':'', '>':'', '<':'', '?':'', \
+                '|':'', '"':''}
 
 def compose_bookname(title, author, edition, isbn):
     bookname = title + ' - ' + author + ', ' + edition + ' - ' + isbn

--- a/helper.py
+++ b/helper.py
@@ -3,12 +3,10 @@ import requests
 import shutil
 
 
-def create_relative_path_if_not_exist(relative_path):
-    path = os.path.join(os.getcwd(), relative_path)
+def create_path(path):
     if not os.path.exists(path):
         os.makedirs(path)
     return path
-
 
 def create_book_file(base_path, bookname, patch):
     output_file = os.path.join(base_path, bookname + patch['ext'])
@@ -20,7 +18,7 @@ def create_book_file(base_path, bookname, patch):
 def download_book(url, book_path):
     if not os.path.exists(book_path):
         with requests.get(url, stream=True) as req:
-            path = create_relative_path_if_not_exist('tmp')
+            path = create_path('./tmp')
             tmp_file = os.path.join(path, '_-_temp_file_-_.bak')
             with open(tmp_file, 'wb') as out_file:
                 shutil.copyfileobj(req.raw, out_file)

--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ for url, title, author, edition, isbn, category in tqdm(books[['OpenURL', 'Book 
             print(e)
             print('* Problem downloading: {}, so skipping it.'.format(title))
             time.sleep(30)
+            request = None
             # then continue to download the next book
 
 print('\nFinish downloading.')

--- a/main.py
+++ b/main.py
@@ -2,15 +2,25 @@
 
 import os
 import requests
-import pandas as pd
 import time
+import argparse
+import pandas as pd
 from tqdm import tqdm
 from helper import *
 
-patches = [
-    {'url':'/content/pdf/', 'ext':'.pdf'},
-    {'url':'/download/epub/', 'ext':'.epub'}
-]
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--pdf', action='store_true' , help='download PDF books', required=False)
+parser.add_argument('--epub', action='store_true' , help='download EPUB books', required=False)
+args = parser.parse_args()
+
+patches = []
+if not args.pdf and not args.epub:
+    args.pdf = args.epub = True
+if args.pdf:
+    patches.append({'url':'/content/pdf/', 'ext':'.pdf'})
+if args.epub:
+    patches.append({'url':'/download/epub/', 'ext':'.epub'})
 
 folder = create_relative_path_if_not_exist('downloads')
 

--- a/main.py
+++ b/main.py
@@ -11,8 +11,8 @@ from helper import *
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-f', '--folder', help='folder to store downloads')
-parser.add_argument('--pdf', action='store_true' , help='download PDF books')
-parser.add_argument('--epub', action='store_true' , help='download EPUB books')
+parser.add_argument('--pdf', action='store_true', help='download PDF books')
+parser.add_argument('--epub', action='store_true', help='download EPUB books')
 args = parser.parse_args()
 
 patches = []
@@ -50,7 +50,6 @@ books = books[
 
 for url, title, author, edition, isbn, category in tqdm(books.values):
     dest_folder = create_path(os.path.join(folder, category))
-    title = title.encode('ascii', 'ignore').decode('ascii')
     bookname = compose_bookname(title, author, edition, isbn)
     request = None
     for patch in patches:
@@ -58,12 +57,13 @@ for url, title, author, edition, isbn, category in tqdm(books.values):
             output_file = create_book_file(dest_folder, bookname, patch)
             if output_file is not None:
                 request = requests.get(url) if request is None else request
-                download_all_books(request, output_file, patch)
-        except (OSError, IOError, requests.exceptions.ConnectionError) as e:
+                download_book(request, output_file, patch)
+        except (OSError, IOError) as e:
             print(e)
+            title = title.encode('ascii', 'ignore').decode('ascii')
             print('* Problem downloading: {}, so skipping it.'.format(title))
             time.sleep(30)
-            request = None
+            request = None                    # Enforce new get request
             # then continue to download the next book
 
 print('\nFinish downloading.')

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from helper import *
 
 
 parser = argparse.ArgumentParser()
+parser.add_argument('-f', '--folder', help='folder to store downloads')
 parser.add_argument('--pdf', action='store_true' , help='download PDF books', required=False)
 parser.add_argument('--epub', action='store_true' , help='download EPUB books', required=False)
 args = parser.parse_args()
@@ -22,7 +23,8 @@ if args.pdf:
 if args.epub:
     patches.append({'url':'/download/epub/', 'ext':'.epub'})
 
-folder = create_relative_path_if_not_exist('downloads')
+folder = args.folder
+folder = create_path(folder) if folder else create_path('./downloads')
 
 table_url = 'https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/v4'
 table = 'table_' + table_url.split('/')[-1] + '.xlsx'
@@ -35,8 +37,19 @@ else:
     books = pd.read_excel(table_path, index_col=0, header=0)
 
 
-for url, title, author, edition, isbn, category in tqdm(books[['OpenURL', 'Book Title', 'Author', 'Edition', 'Electronic ISBN', 'English Package Name']].values):
-    dest_folder = create_relative_path_if_not_exist(os.path.join(folder, category))
+books = books[
+    [
+      'OpenURL',
+      'Book Title',
+      'Author',
+      'Edition',
+      'Electronic ISBN',
+      'English Package Name'
+    ]
+]
+
+for url, title, author, edition, isbn, category in tqdm(books.values):
+    dest_folder = create_path(os.path.join(folder, category))
     title = title.encode('ascii', 'ignore').decode('ascii')
     bookname = compose_bookname(title, author, edition, isbn)
     request = None

--- a/main.py
+++ b/main.py
@@ -11,8 +11,8 @@ from helper import *
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-f', '--folder', help='folder to store downloads')
-parser.add_argument('--pdf', action='store_true' , help='download PDF books', required=False)
-parser.add_argument('--epub', action='store_true' , help='download EPUB books', required=False)
+parser.add_argument('--pdf', action='store_true' , help='download PDF books')
+parser.add_argument('--epub', action='store_true' , help='download EPUB books')
 args = parser.parse_args()
 
 patches = []


### PR DESCRIPTION
The last inclusion of `try-except` code messed up with `Crtl-C` and `Ctrl-Break`. Also, by checking only the existence of a `PDF` file to skip the download causes the `EPUB` to be skipped as well, which is undesirable. This patch fixes those. However, it runs slower even though all books have been downloaded, but much faster than the original one. This is because some books do not have `EPUB` and the script will probe since those books are non-existence on the local drive, thus taking up more time.

I also included a simple command-line options to choose either to download PDF only or EPUB only. It will download both book formats if no option is given. There is an option to choose where to store all the downloaded files. By default the download folder is `./downloads`.

As a side note, if you choose to download PDF only and provided that you have all the books on your drive, it runs as fast as Dovyski's modification because it will not probe for the missing EPUBs.