### PR TITLE
Fixed wrong index numbering

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -2,13 +2,14 @@ import os
 import re
 import requests
 import shutil
+import time
 import pandas as pd
 import numpy as np
-import time
 from tqdm import tqdm
 
 BOOK_TITLE = 'Book Title'
 CATEGORY   = 'English Package Name'
+MAX_FILENAME_LEN = 145
 
 def create_path(path):
     if not os.path.exists(path):
@@ -18,15 +19,12 @@ def create_path(path):
 def create_book_file(base_path, bookname, patch):
     """
     Create a file to store book content and return the file reference
+    if it is newly created. Otherwise return None.
     """
     output_file = os.path.join(base_path, bookname + patch['ext'])
     if os.path.exists(output_file):
         return None
     return output_file
-
-
-def remove_duplicate_tuples(lst):
-    return tuple(set(lst))
 
 
 def print_invalid_categories(invalid_categories):
@@ -41,12 +39,12 @@ def print_invalid_categories(invalid_categories):
         print('')
 
 
-def print_summary(books, args, invalid_categories):
+def print_summary(books, invalid_categories, args):
     # Set Pandas to no maximum row limit
     pd.set_option('display.max_rows', None)
     if args.verbose:
-      # Print all titles to be downloaded
-      print(books.loc[:, (BOOK_TITLE, CATEGORY)])
+        # Print all titles to be downloaded
+        print(books.loc[:, (BOOK_TITLE, CATEGORY)])
     print("\n{} titles ready to be downloaded...".format(len(books.index)))
     print_invalid_categories(invalid_categories)
 
@@ -54,8 +52,8 @@ def print_summary(books, args, invalid_categories):
 def filter_books(books, indices):
     if len(indices) == 0:
         # If no books selected, then select all books
-        indices = tuple(range(0, len(books.index)))
-    # Filter books and return it
+        indices = range(0, len(books.index))
+    # Return the filtered books
     return books.loc[indices, :]
 
 
@@ -70,10 +68,10 @@ def indices_of_categories(categories, books):
             t = t | tick_list
         else:
             invalid_categories.append(c)
-    return tuple(books.index[t].tolist()), invalid_categories
+    return books.index[t].tolist(), invalid_categories
 
 
-def _download_book(url, book_path):
+def download_book(url, book_path):
     if not os.path.exists(book_path):
         with requests.get(url, stream=True) as req:
             path = create_path('./tmp')
@@ -84,14 +82,14 @@ def _download_book(url, book_path):
             shutil.move(tmp_file, book_path)
 
 
-def download_book(request, output_file, patch):
+def download_book_if_exists(request, output_file, patch):
     new_url = request.url.replace('%2F','/').replace('/book/', patch['url']) + patch['ext']
     request = requests.get(new_url, stream=True)
     if request.status_code == 200:
-        _download_book(new_url, output_file)
+        download_book(new_url, output_file)
 
 
-def download_selected_books(books, folder, patches):
+def download_books(books, folder, patches):
     books = books[
         [
           'OpenURL',
@@ -111,7 +109,7 @@ def download_selected_books(books, folder, patches):
                 output_file = create_book_file(dest_folder, bookname, patch)
                 if output_file is not None:
                     request = requests.get(url) if request is None else request
-                    download_book(request, output_file, patch)
+                    download_book_if_exists(request, output_file, patch)
             except (OSError, IOError) as e:
                 print(e)
                 title = title.encode('ascii', 'ignore').decode('ascii')
@@ -127,14 +125,14 @@ replacements = {'/':'-', '\\':'-', ':':'-', '*':'', '>':'', '<':'', '?':'', \
 
 def compose_bookname(title, author, edition, isbn):
     bookname = title + ' - ' + author + ', ' + edition + ' - ' + isbn
-    if(len(bookname) > 145):
+    if(len(bookname) > MAX_FILENAME_LEN):
         bookname = title + ' - ' + author.split(',')[0] + ' et al., ' + \
                     edition + ' - ' + isbn
-    if(len(bookname) > 145):
+    if(len(bookname) > MAX_FILENAME_LEN):
         bookname = title + ' - ' + author.split(',')[0] + ' et al. - ' + isbn
-    if(len(bookname) > 145):
+    if(len(bookname) > MAX_FILENAME_LEN):
         bookname = title + ' - ' + isbn
-    if(len(bookname) > 145):
-        bookname = title[:130] + ' - ' + isbn
+    if(len(bookname) > MAX_FILENAME_LEN):
+        bookname = title[:(MAX_FILENAME_LEN - 20)] + ' - ' + isbn
     bookname = bookname.encode('ascii', 'ignore').decode('ascii')
     return "".join([replacements.get(c, c) for c in bookname])


### PR DESCRIPTION
The problem was brought to my attention through issue #73.

The Excel file downloaded into the `./download` folder has added _index_ column which the script used to refer to the titles. However, the index numbering of the newly added one (red) is different from the real index numbering (orange) of the Excel sheet. This has caused confusion to those who downloaded the Excel sheet directly from the Springer website, which did not have the added column (red). To remedy this, I have amended the code to adjust the numbering to match the real index numbering before processing. So the first book will be on index 2 instead of 0. 

![indices](https://user-images.githubusercontent.com/2726488/80731641-c144d100-8b3d-11ea-873d-904f4c08e3e1.png)

 
