### PR TITLE
Generate human friendly error message

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ if not os.path.exists(table_path):
     except (OSError, IOError) as e:
         if e.__class__.__name__ == 'HTTPError' and e.getcode() == 404:
             print('Error: {} URL page not found. '.format(table_url) +
-                  'Please contact intelligent human for help.')
+                  'Fix the URL in the Python script, or get someone to help.')
         else:
             print(e)
         exit(-1)

--- a/main.py
+++ b/main.py
@@ -34,7 +34,15 @@ table_url = 'https://resource-cms.springernature.com/springer-cms/rest/v1/conten
 table = 'table_' + table_url.split('/')[-1] + '.xlsx'
 table_path = os.path.join(folder, table)
 if not os.path.exists(table_path):
-    books = pd.read_excel(table_url)
+    try:
+        books = pd.read_excel(table_url)
+    except (OSError, IOError) as e:
+        if e.__class__.__name__ == 'HTTPError' and e.getcode() == 404:
+            print('Error: {} URL page not found. '.format(table_url) +
+                  'Please contact intelligent human for help.')
+        else:
+            print(e)
+        exit(-1)
     # Save table in the download folder
     books.to_excel(table_path)
 else:


### PR DESCRIPTION
I made 2 improvements:
1.  Added some code lines so that when the link to the Springer Excel file is broken, it generates a human friendly message with one extra info. This may prevent misunderstanding (#89 and #85) and can help user understand the problem encountered by printing out the faulty URL.
2.  Reduced the call to requests.get()
