### PR TITLE
Add German books downloading via --lang/-l

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,7 @@ It used to have 409 english books (it took about 4 hours to complete the downloa
 
 By default the script stores the books in `./downloads` subfolder according to the subject ("English Package Name" column of the excel file).
 
-#### Download all books (PDF and EPUB)
+#### Download all English books (PDF and EPUB)
 Use the following command to download all PDF and EPUB books to the default download folder `./downloads`
 ```bash
 python3 main.py
@@ -21,6 +21,14 @@ You can download to an absolute path, say `C:/ebooks/springer/`
 ```bash
 python3 main.py -f C:/ebooks/springer/
 ```
+
+### Download all German books (PDF and EPUB)
+To download the German books use
+```bash
+python3 main.py --lang de
+```
+This language flag can be combined with any of the above and below mentioned options. If not specified, `--lang en`, i.e. English, is
+the default.
 
 #### Download all books of specific format
 To download all PDF books only, run

--- a/main.py
+++ b/main.py
@@ -8,6 +8,9 @@ from helper import *
 
 
 parser = argparse.ArgumentParser()
+parser.add_argument('-l', '--lang', dest='language',
+    default='en', choices={'en', 'de'}, help='books language to download'
+)
 parser.add_argument('-f', '--folder', help='folder to store downloads')
 parser.add_argument(
     '--pdf', action='store_true', help='download PDF books'
@@ -30,8 +33,13 @@ parser.add_argument(
 args = parser.parse_args()
 folder = create_path(args.folder if args.folder else './downloads')
 
-table_url = 'https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/'
-table = 'table_' + table_url.split('/')[-1] + '.xlsx'
+assert args.language in ('en', 'de'), '-l or --language must be "en" or "de"'
+if args.language == 'en':
+    table_url = 'https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/'
+elif args.language == 'de':
+    table_url = 'https://resource-cms.springernature.com/springer-cms/rest/v1/content/17863240/data/'
+ 
+table = 'table_' + table_url.split('/')[-1] + '_' + args.language + '.xlsx'
 table_path = os.path.join(folder, table)
 if not os.path.exists(table_path):
     books = pd.read_excel(table_url)


### PR DESCRIPTION
Springer also offers some German books. This PR adds a `--lang/-l` flag to select between English (`en`) and German (`de`) books. The default is `en`.