### PR TITLE
Make downloading of books multithreaded, controlled via -j/--jobs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,6 +21,10 @@ You can download to an absolute path, say `C:/ebooks/springer/`
 ```bash
 python3 main.py -f C:/ebooks/springer/
 ```
+Parallel downloading, say with 3 jobs, can be enabled with
+```bash
+python3 main.py -j 3
+```
 
 ### Download all German books (PDF and EPUB)
 To download the German books use

--- a/helper.py
+++ b/helper.py
@@ -44,10 +44,10 @@ def print_invalid_categories(invalid_categories):
         # Remove duplicates
         invalid_categories = series[~series.duplicated()]
         s = 'categories' if len(invalid_categories) > 1 else 'category'
-        print("The following invalid book {} will be ignored:".format(s))
+        tqdm.write("The following invalid book {} will be ignored:".format(s))
         for i, name in enumerate(invalid_categories):
-            print(" {}. {}".format((i + 1), name))
-        print('')
+            tqdm.write(" {}. {}".format((i + 1), name))
+        tqdm.write('')
 
 
 def print_summary(books, invalid_categories, args):
@@ -55,8 +55,8 @@ def print_summary(books, invalid_categories, args):
     pd.set_option('display.max_rows', None)
     if args.verbose:
         # Print all titles to be downloaded
-        print(books.loc[:, (BOOK_TITLE, CATEGORY)])
-    print("\n{} titles ready to be downloaded...".format(len(books.index)))
+        tqdm.write(str(books.loc[:, (BOOK_TITLE, CATEGORY)]))
+    tqdm.write("\n{} titles ready to be downloaded...".format(len(books.index)))
     print_invalid_categories(invalid_categories)
 
 
@@ -151,9 +151,9 @@ def download_books(books, folder, patches, jobs):
     max_length = get_max_filename_length(folder)
     longest_name = books[CATEGORY].map(len).max()
     if max_length - longest_name < MIN_FILENAME_LEN:
-        print('The download directory path is too lengthy:')
-        print('{}'.format(os.path.abspath(folder)))
-        print('Please choose a shorter one')
+        tqdm.write('The download directory path is too lengthy:')
+        tqdm.write('{}'.format(os.path.abspath(folder)))
+        tqdm.write('Please choose a shorter one')
         exit(-1)
     books = books[
         [

--- a/main.py
+++ b/main.py
@@ -27,12 +27,17 @@ parser.add_argument(
     help='list of book indices to download'
 )
 parser.add_argument(
+    '-j', '--jobs', dest='jobs', type=int, default=1,
+    help='number of parallel download jobs'
+)
+parser.add_argument(
     '-v','--verbose', action='store_true', help='show more details'
 )
 
 args = parser.parse_args()
 folder = create_path(args.folder if args.folder else './downloads')
 
+assert args.jobs > 0, '-j or --jobs must be > 0'
 assert args.language in ('en', 'de'), '-l or --language must be "en" or "de"'
 if args.language == 'en':
     table_url = 'https://resource-cms.springernature.com/springer-cms/rest/v1/content/17858272/data/'
@@ -85,6 +90,6 @@ indices = list(set(indices))                            # Remove duplicates
 books = filter_books(books, sorted(indices))
 books.index = [i + 2 for i in books.index]              # Recorrect indices
 print_summary(books, invalid_categories, args)
-download_books(books, folder, patches)
+download_books(books, folder, patches, args.jobs)
 
 print('\nFinish downloading.')


### PR DESCRIPTION
A simple (unscientific) timing: I downloaded the 10 first German books with `-j 1` and `-j 4`:

Single-threaded: 7m48s
Four threads: 2m41s

This is a factor of 2.9 faster.