### PR TITLE
fix: reconstruct correct url for epub and pdf

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -159,14 +159,18 @@ def download_books(books, folder, patches):
             length = MAX_FILENAME_LEN
         bookname = compose_bookname(title, author, edition, isbn, length)
         request = None
+        init_request_url = None
         for patch in patches:
             try:
                 if not patch['dl_chapters']:
                     output_file = get_book_path_if_new(dest_folder, bookname, patch)
                     if output_file is not None:
-                        request = requests.get(url) if request is None else request
-                        new_url = request.url.replace('%2F', '/').replace('/book/', patch['url']) + patch['ext']
-                        request = requests.get(new_url, stream=True)
+                         # save init request url so we can reuse to construct both pdf and epub download paths
+                        if init_request_url is None:
+                            init_request = requests.get(url) 
+                            init_request_url = init_request.url
+                        new_url = init_request_url.replace('%2F', '/').replace('/book/', patch['url']) + patch['ext']
+                        requests.get(new_url, stream=True)
                         download_item(new_url, output_file)
                 else:
                     # download in chapters


### PR DESCRIPTION
Fixes #107 .  

Verified this only with the use case of downloading full English books. Did not test with other use cases (e.g german language, downloading individual chapters, etc.)